### PR TITLE
Support Images for facebook scraping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 build/
 .pytest_cache/
 .claude/
+dev/
+venv/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -6,19 +6,23 @@ This library aims to help developers and researchers to easily access multimodal
 ## Setup
 * **If you want to download videos**: Then, the installation of [ffmpeg](https://ffmpeg.org/) is highly recommended.
 In Conda, you can install it with `conda install -c conda-forge ffmpeg`.
-* **If you want to scrape Perma.cc archive records**, you'll need to install playwright with `pip install playwright` and running `playwright install`.
+* **If you want to scrape Perma.cc archive records or Facebook photos**, you'll need to install playwright with `pip install playwright` and running `playwright install`.
 
 ## Usage
 ```python
 from scrapemm import retrieve
 import asyncio
 
-url = "https://example.com"
-loop = asyncio.get_event_loop()
-result = loop.run_until_complete(retrieve(url))
-result.render()
+if __name__ == "__main__":
+    url = "https://www.snopes.com/fact-check/gauze-originate-from-gaza/"
+    result = asyncio.run(retrieve(url))
+    if result.errors:
+        print(result.errors)
+    else:
+        print(result.content)
 ```
-`scrapeMM` will ask you for the **API keys** needed for the social media integrations. You may skip them if you don't need them. 
+`scrapeMM` will ask you for the **API secrets** needed for the integrations. You may skip them if you don't need them.
+
 You will also be prompted to choose a **password** that is used to secure the secrets in an encrypted file.
 
 ## How it works
@@ -38,14 +42,14 @@ Web scraping is done with [Firecrawl](https://github.com/mendableai/firecrawl) a
 - ✅ TikTok
 - ✅ YouTube
 - (✅️) Instagram: works for most content
-- ⏳ Facebook: done for videos but not for images yet
+- ✅️ Facebook
 - ❌ Threads: TBD
 - ❌ Reddit: TBD
 
 ### Archiving Services
-- ❌ Perma.cc
-- ❌ Archive.today
+- ✅ Perma.cc
+- (✅) Archive.today: Sometimes ending up in TimeoutErrors, generally pretty slow
+- ✅ MediaVault (mvau.lt)
 - ❌ Wayback Machine, Internet Archive (web.archive.org)
 - ❌ AwesomeScreenshot.com
-- ⏳ MediaVault (mvau.lt): Works for images but not for videos yet
 - ❌ Ghost Archive (ghostarchive.org)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pytest~=8.4.1
-aiohttp~=3.12.13
-numpy~=1.26.4
+aiohttp~=3.13.5
 requests~=2.32.4
 ezMM~=0.5.1
 Telethon~=1.40.0
@@ -13,12 +12,12 @@ async_lru
 oauthlib
 platformdirs~=4.3.8
 atproto
-TikTokResearchApi
-yt-dlp
+TikTokResearchApi~=1.0.4
 yt-dlp[default,curl-cffi]
+curl_cffi~=0.14.0b5  # yt-dlp doesn't support 0.15+ yet
 cryptography
 firecrawl-py~=4.10.4
-brotli
+brotli  # Required to read brotli-encoded media
 playwright
 playwright-stealth
 beautifulsoup4

--- a/scrapemm/integrations/fb.py
+++ b/scrapemm/integrations/fb.py
@@ -1,13 +1,13 @@
 import logging
 import re
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
 import aiohttp
 from ezmm import MultimodalSequence
-from playwright.async_api import async_playwright
-from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+from ezmm.common.items import Image
 from markdownify import markdownify as md
-
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+from playwright.async_api import async_playwright
 
 from scrapemm import RateLimitError
 from scrapemm.common import CONFIG_DIR
@@ -22,7 +22,10 @@ from scrapemm.util import parse_netscape_cookies, postprocess_scraped
 logger = logging.getLogger("scrapeMM")
 
 VIDEO_URL_REGEX = r"facebook\.com/\d+/videos/\d+/?"
-LIKE_COMMENT_SHARE_SVG_REGEX = r"['\"]?%[0-9A-Fa-f]{2}.*?(?:%3C/svg%3E|%3C%2Fsvg%3E)['\"]?"
+LIKE_COMMENT_SHARE_SVG_REGEX = (
+    r"['\"]?%[0-9A-Fa-f]{2}.*?(?:%3C/svg%3E|%3C%2Fsvg%3E)['\"]?"
+)
+FB_PHOTO_HREF_REGEX = r'href="(https://www\.facebook\.com/photo/[^"]*)"'
 
 JS_GET_MEDIA_VC_IMAGE = """
     () => {
@@ -37,7 +40,6 @@ JS_GET_OG_IMAGE = """
         return og ? og.getAttribute('content') : null;
     }
 """.strip()
-
 
 
 class Facebook(RetrievalIntegration):
@@ -55,7 +57,9 @@ class Facebook(RetrievalIntegration):
                 f.write(cookie)
             logger.info("✅ Using cookie to connect to Facebook.")
         else:
-            logger.warning("⚠️ Missing Facebook cookie. Won't be able to download videos that require login.")
+            logger.warning(
+                "⚠️ Missing Facebook cookie. Won't be able to download videos that require login."
+            )
 
         logger.info("✅ Facebook integration ready (yt-dlp only mode).")
         self.connected = True
@@ -72,7 +76,9 @@ class Facebook(RetrievalIntegration):
                 if "No video formats found" in str(e):
                     raise ContentBlockedError("Video is blocked by Facebook.")
                 elif "This video is only available for registered users" in str(e):
-                    raise RateLimitError("Facebook is rate-limiting your IP address. Set a 'facebook_cookie' in ScrapeMM.")
+                    raise RateLimitError(
+                        "Facebook is rate-limiting your IP address. Set a 'facebook_cookie' in ScrapeMM."
+                    )
                 else:
                     raise e
         elif self._is_photo_url(url):
@@ -103,18 +109,33 @@ class Facebook(RetrievalIntegration):
     async def _get_video(self, url: str, **kwargs) -> MultimodalSequence | None:
         """Retrieves content from a Facebook video URL."""
         if self.api_available:
-            raise NotImplementedError("Facebook video retrieval through API not yet supported.")
+            raise NotImplementedError(
+                "Facebook video retrieval through API not yet supported."
+            )
         else:
-            return await get_content_with_ytdlp(url,
-                                                platform="Facebook",
-                                                cookiefile=self.cookie_file.as_posix(),
-                                                # impersonate=ImpersonateTarget("Chrome", "136"),
-                                                **kwargs)
+            return await get_content_with_ytdlp(
+                url,
+                platform="Facebook",
+                cookiefile=self.cookie_file.as_posix(),
+                # impersonate=ImpersonateTarget("Chrome", "136"),
+                **kwargs,
+            )
 
     async def _get_photo(self, url: str, **kwargs) -> MultimodalSequence | None:
         """Retrieves content from a Facebook photo URL using Playwright with session cookies."""
         cookies = parse_netscape_cookies(self.cookie_file)
 
+        if self._is_post_permalink(url):
+            photos = await self._get_mm_sequences_from_post_permalink(
+                url, cookies, **kwargs
+            )
+            return MultimodalSequence(photos)
+
+        return await self._get_mm_sequence_from_regular_post(url, cookies)
+
+    async def _get_mm_sequence_from_regular_post(
+        self, url, cookies: list[dict[str, str]]
+    ) -> MultimodalSequence | None:
         image_url = None
         async with async_playwright() as p:
             browser = await p.chromium.launch(headless=True)
@@ -145,14 +166,57 @@ class Facebook(RetrievalIntegration):
 
         if not image:
             raise RuntimeError("Could not download image from Facebook photo.")
-        
+
         # Retrieve text only
         text = md(html, heading_style="ATX")
         postprocessed_text = postprocess_scraped(text)
         # Remove SVG icons for like/comment/share
-        postprocessed_text = re.sub(LIKE_COMMENT_SHARE_SVG_REGEX, "", str(postprocessed_text))
+        postprocessed_text = re.sub(
+            LIKE_COMMENT_SHARE_SVG_REGEX, "", str(postprocessed_text)
+        )
 
         return MultimodalSequence([image, postprocessed_text])
+
+    async def _get_mm_sequences_from_post_permalink(
+        self, url: str, cookies: list[dict[str, str]], **kwargs
+    ) -> list[Image]:
+        """Retrieves all photos from a Facebook post permalink URL."""
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(headless=True)
+            context = await browser.new_context(user_agent=HEADERS["User-Agent"])
+            if cookies:
+                await context.add_cookies(cookies)
+            page = await context.new_page()
+
+            try:
+                try:
+                    await page.goto(url, timeout=30000)
+                    await page.wait_for_load_state("domcontentloaded")
+
+                except PlaywrightTimeoutError:
+                    raise RuntimeError("Timed out loading Facebook photo page.")
+
+                html = await page.content()
+                photo_hrefs = self._collect_photo_hrefs_from_html(html)
+
+            finally:
+                await browser.close()
+
+            photos = [
+                await self._get_mm_sequence_from_regular_post(href, cookies)
+                for href in photo_hrefs
+            ]
+
+            return [photo.images[0] for photo in photos if photo]
+
+    def _is_post_permalink(self, url: str) -> bool:
+        """Checks if the URL is a Facebook post permalink URL."""
+        return re.search(r"facebook\.com/.+/posts/.+", url) is not None
+
+    def _collect_photo_hrefs_from_html(self, html: str) -> list[str]:
+        """Collects all photo hrefs from the given HTML string."""
+        hrefs = re.findall(FB_PHOTO_HREF_REGEX, html)
+        return hrefs
 
     async def _get_user_profile(self, url: str, **kwargs) -> MultimodalSequence | None:
         """Retrieves content from a Facebook user profile URL."""
@@ -161,10 +225,14 @@ class Facebook(RetrievalIntegration):
     def _normalize_url(self, url: str) -> str:
         """If the URL is a login Facebook URL, i.e., of the form https://www.facebook.com/login/?next=...
         or https://www.facebook.com/plugins/post.php?href=..., extracts the actual post's URL."""
-        if url.startswith("https://www.facebook.com/login/?next="):  # Login redirect URLs
+        if url.startswith(
+            "https://www.facebook.com/login/?next="
+        ):  # Login redirect URLs
             query = urlparse(url).query
             return parse_qs(query).get("next", [])[0] or url
-        elif url.startswith("https://www.facebook.com/plugins/post.php?href="):  # Post embedding links
+        elif url.startswith(
+            "https://www.facebook.com/plugins/post.php?href="
+        ):  # Post embedding links
             query = urlparse(url).query
             return parse_qs(query).get("href", [])[0] or url
         return url
@@ -173,19 +241,21 @@ class Facebook(RetrievalIntegration):
         """Checks if the URL is a Facebook video URL."""
         # video URLS are in the format: https://www.facebook.com/watch?v=VIDEO_ID or fb.watch/...
         # or Reels: https://www.facebook.com/reel/REEL_ID
-        return ("facebook.com/watch" in url
-                or "facebook.com/reel" in url
-                or bool(re.search(VIDEO_URL_REGEX, url))
-                or "fb.watch" in url
-                or "/videos/" in url)
+        return (
+            "facebook.com/watch" in url
+            or "facebook.com/reel" in url
+            or bool(re.search(VIDEO_URL_REGEX, url))
+            or "fb.watch" in url
+            or "/videos/" in url
+        )
 
     def _extract_video_id(self, url: str) -> str:
         """Extracts the video ID from a Facebook video URL."""
         parsed_url = urlparse(url)
         query_params = parsed_url.query
-        for param in query_params.split('&'):
-            if param.startswith('v='):
-                return param.split('=')[1]
+        for param in query_params.split("&"):
+            if param.startswith("v="):
+                return param.split("=")[1]
         return ""
 
     def _is_photo_url(self, url: str) -> bool:
@@ -196,7 +266,7 @@ class Facebook(RetrievalIntegration):
         """Extracts the username from a Facebook profile URL."""
         # url format: https://www.facebook.com/username<?...>
         parsed_url = urlparse(url)
-        path_parts = parsed_url.path.strip('/').split('/')
+        path_parts = parsed_url.path.strip("/").split("/")
         if len(path_parts) > 0:
             return path_parts[0]
         return ""

--- a/scrapemm/integrations/fb.py
+++ b/scrapemm/integrations/fb.py
@@ -8,6 +8,7 @@ from ezmm.common.items import Image
 from markdownify import markdownify as md
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 from playwright.async_api import async_playwright
+from yt_dlp.networking.impersonate import ImpersonateTarget
 
 from scrapemm import RateLimitError
 from scrapemm.common import CONFIG_DIR
@@ -116,8 +117,8 @@ class Facebook(RetrievalIntegration):
             return await get_content_with_ytdlp(
                 url,
                 platform="Facebook",
-                cookiefile=self.cookie_file.as_posix(),
-                # impersonate=ImpersonateTarget("Chrome", "136"),
+                # cookiefile=self.cookie_file.as_posix(),
+                impersonate=ImpersonateTarget("chrome", "133"),
                 **kwargs,
             )
 

--- a/scrapemm/integrations/fb.py
+++ b/scrapemm/integrations/fb.py
@@ -2,18 +2,42 @@ import logging
 import re
 from urllib.parse import urlparse, parse_qs
 
+import aiohttp
 from ezmm import MultimodalSequence
+from playwright.async_api import async_playwright
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+from markdownify import markdownify as md
+
 
 from scrapemm import RateLimitError
 from scrapemm.common import CONFIG_DIR
 from scrapemm.common.exceptions import ContentBlockedError
+from scrapemm.download import download_image
+from scrapemm.download.common import HEADERS
 from scrapemm.integrations.base import RetrievalIntegration
 from scrapemm.integrations.ytdlp import get_content_with_ytdlp
 from scrapemm.secrets import get_secret
+from scrapemm.util import parse_netscape_cookies, postprocess_scraped
 
 logger = logging.getLogger("scrapeMM")
 
 VIDEO_URL_REGEX = r"facebook\.com/\d+/videos/\d+/?"
+LIKE_COMMENT_SHARE_SVG_REGEX = r"['\"]?%[0-9A-Fa-f]{2}.*?(?:%3C/svg%3E|%3C%2Fsvg%3E)['\"]?"
+
+JS_GET_MEDIA_VC_IMAGE = """
+    () => {
+        const img = document.querySelector('img[data-visualcompletion="media-vc-image"]');
+        return img ? img.getAttribute('src') : null;
+    }
+""".strip()
+
+JS_GET_OG_IMAGE = """
+    () => {
+        const og = document.querySelector('meta[property="og:image"]');
+        return og ? og.getAttribute('content') : null;
+    }
+""".strip()
+
 
 
 class Facebook(RetrievalIntegration):
@@ -29,11 +53,11 @@ class Facebook(RetrievalIntegration):
             # Save the cookie in a .txt file next to the secrets file
             with open(self.cookie_file, "w") as f:
                 f.write(cookie)
-            logger.info(f"✅ Using cookie to connect to Facebook.")
+            logger.info("✅ Using cookie to connect to Facebook.")
         else:
-            logger.warning(f"⚠️ Missing Facebook cookie. Won't be able to download videos that require login.")
+            logger.warning("⚠️ Missing Facebook cookie. Won't be able to download videos that require login.")
 
-        logger.info(f"✅ Facebook integration ready (yt-dlp only mode).")
+        logger.info("✅ Facebook integration ready (yt-dlp only mode).")
         self.connected = True
 
     async def _get(self, url: str, **kwargs) -> MultimodalSequence | None:
@@ -46,9 +70,9 @@ class Facebook(RetrievalIntegration):
                 return await self._get_video(url, **kwargs)
             except Exception as e:
                 if "No video formats found" in str(e):
-                    raise ContentBlockedError(f"Video is blocked by Facebook.")
+                    raise ContentBlockedError("Video is blocked by Facebook.")
                 elif "This video is only available for registered users" in str(e):
-                    raise RateLimitError(f"Facebook is rate-limiting your IP address. Set a 'facebook_cookie' in ScrapeMM.")
+                    raise RateLimitError("Facebook is rate-limiting your IP address. Set a 'facebook_cookie' in ScrapeMM.")
                 else:
                     raise e
         elif self._is_photo_url(url):
@@ -83,13 +107,52 @@ class Facebook(RetrievalIntegration):
         else:
             return await get_content_with_ytdlp(url,
                                                 platform="Facebook",
-                                                cookie_file=self.cookie_file.as_posix(),
+                                                cookiefile=self.cookie_file.as_posix(),
                                                 # impersonate=ImpersonateTarget("Chrome", "136"),
                                                 **kwargs)
 
     async def _get_photo(self, url: str, **kwargs) -> MultimodalSequence | None:
-        """Retrieves content from a Facebook photo URL."""
-        raise NotImplementedError("No method available to retrieve Facebook photos.")
+        """Retrieves content from a Facebook photo URL using Playwright with session cookies."""
+        cookies = parse_netscape_cookies(self.cookie_file)
+
+        image_url = None
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(headless=True)
+            context = await browser.new_context(user_agent=HEADERS["User-Agent"])
+            if cookies:
+                await context.add_cookies(cookies)
+            page = await context.new_page()
+            try:
+                try:
+                    await page.goto(url, timeout=30000)
+                    await page.wait_for_load_state("domcontentloaded")
+                except PlaywrightTimeoutError:
+                    raise RuntimeError("Timed out loading Facebook photo page.")
+
+                image_url = await page.evaluate(JS_GET_MEDIA_VC_IMAGE)
+
+                if not image_url:
+                    image_url = await page.evaluate(JS_GET_OG_IMAGE)
+            finally:
+                html = await page.content()
+                await browser.close()
+
+        if not image_url:
+            raise RuntimeError("Could not locate image on Facebook photo page.")
+
+        async with aiohttp.ClientSession(headers=HEADERS) as session:
+            image = await download_image(image_url, session)
+
+        if not image:
+            raise RuntimeError("Could not download image from Facebook photo.")
+        
+        # Retrieve text only
+        text = md(html, heading_style="ATX")
+        postprocessed_text = postprocess_scraped(text)
+        # Remove SVG icons for like/comment/share
+        postprocessed_text = re.sub(LIKE_COMMENT_SHARE_SVG_REGEX, "", str(postprocessed_text))
+
+        return MultimodalSequence([image, postprocessed_text])
 
     async def _get_user_profile(self, url: str, **kwargs) -> MultimodalSequence | None:
         """Retrieves content from a Facebook user profile URL."""

--- a/scrapemm/integrations/fb.py
+++ b/scrapemm/integrations/fb.py
@@ -126,14 +126,14 @@ class Facebook(RetrievalIntegration):
         cookies = parse_netscape_cookies(self.cookie_file)
 
         if self._is_post_permalink(url):
-            photos = await self._get_mm_sequences_from_post_permalink(
+            photos = await self._get_photos_from_post_permalink(
                 url, cookies, **kwargs
             )
             return MultimodalSequence(photos)
 
-        return await self._get_mm_sequence_from_regular_post(url, cookies)
+        return await self._get_photo_from_regular_post(url, cookies)
 
-    async def _get_mm_sequence_from_regular_post(
+    async def _get_photo_from_regular_post(
         self, url, cookies: list[dict[str, str]]
     ) -> MultimodalSequence | None:
         image_url = None
@@ -177,7 +177,7 @@ class Facebook(RetrievalIntegration):
 
         return MultimodalSequence([image, postprocessed_text])
 
-    async def _get_mm_sequences_from_post_permalink(
+    async def _get_photos_from_post_permalink(
         self, url: str, cookies: list[dict[str, str]], **kwargs
     ) -> list[Image]:
         """Retrieves all photos from a Facebook post permalink URL."""
@@ -203,7 +203,7 @@ class Facebook(RetrievalIntegration):
                 await browser.close()
 
             photos = [
-                await self._get_mm_sequence_from_regular_post(href, cookies)
+                await self._get_photo_from_regular_post(href, cookies)
                 for href in photo_hrefs
             ]
 

--- a/scrapemm/integrations/youtube.py
+++ b/scrapemm/integrations/youtube.py
@@ -38,5 +38,5 @@ class YouTube(RetrievalIntegration):
         """Downloads YouTube video or short using yt-dlp."""
         return await get_content_with_ytdlp(url,
                                             platform="YouTube",
-                                            cookie_file=self.cookie_file.as_posix(),
+                                            cookiefile=self.cookie_file.as_posix(),
                                             **kwargs)

--- a/scrapemm/integrations/youtube.py
+++ b/scrapemm/integrations/youtube.py
@@ -36,7 +36,9 @@ class YouTube(RetrievalIntegration):
 
     async def _get(self, url: str, **kwargs) -> Optional[MultimodalSequence]:
         """Downloads YouTube video or short using yt-dlp."""
+        cookie = get_secret("youtube_cookie")
+        cookie_file_path = self.cookie_file.as_posix() if cookie else None
         return await get_content_with_ytdlp(url,
                                             platform="YouTube",
-                                            cookiefile=self.cookie_file.as_posix(),
+                                            cookiefile=cookie_file_path,
                                             **kwargs)

--- a/scrapemm/secrets.py
+++ b/scrapemm/secrets.py
@@ -155,6 +155,7 @@ def remove_secret(key_name: str):
     data = _load_secrets()
     data.pop(key_name, None)
     _save_secrets(data)
+    logger.info(f"Removed secret {key_name}.")
 
 
 def configure_secrets(all_keys: bool = False):

--- a/scrapemm/util.py
+++ b/scrapemm/util.py
@@ -196,6 +196,7 @@ def decompose_data_uri(href: str) -> Optional[tuple[str, str]]:
 
 async def to_multimodal_sequence(
         html: str | None,
+        session: aiohttp.ClientSession,
         **kwargs
 ) -> Optional[MultimodalSequence]:
     """Turns a scraped output into the corresponding MultimodalSequences
@@ -206,7 +207,7 @@ async def to_multimodal_sequence(
         return None
 
     text = postprocess_scraped(text)
-    return await resolve_media_hyperlinks(text, **kwargs)
+    return await resolve_media_hyperlinks(text, session=session, **kwargs)
 
 
 def sanitize(text: str) -> str:
@@ -324,3 +325,37 @@ def run_command(cmd: list[str]) -> subprocess.CompletedProcess | None:
     except UnicodeDecodeError:
         logger.debug(f"Error running command {cmd}: Unicode decoding failed")
         return None
+
+def parse_netscape_cookies(cookie_file: Path) -> list[dict]:
+    """Parse the Netscape-format cookie file and return cookie dicts.
+
+    Netscape format fields (tab-separated):
+        domain  include_subdomains  path  is_secure  expiry  name  value
+    """
+    if not cookie_file.exists():
+        return []
+
+    cookies = []
+    with open(cookie_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("\t")
+            if len(parts) < 7:
+                continue
+            domain, _include_subdomains, path, is_secure, expiry, name, value = parts[:7]
+            try:
+                cookies.append({
+                    "name": name,
+                    "value": value,
+                    "domain": domain,
+                    "path": path,
+                    "expires": int(expiry),
+                    "httpOnly": False,
+                    "secure": is_secure.upper() == "TRUE",
+                    "sameSite": "None",
+                })
+            except ValueError:
+                continue
+    return cookies

--- a/testing/test_archiving_site.py
+++ b/testing/test_archiving_site.py
@@ -22,15 +22,15 @@ from test_social_media import assert_expectations
     ("https://archive.ph/movd4", dict(image=1)),  # Online article
     ("https://archive.vn/Edqcv", dict(image=1)),  # Online article
     ("https://archive.fo/jnN0O", dict(image=1)),  # Older Facebook post
-    # Other archiving services:
-    ("https://mvau.lt/media/b286c959-00da-4765-8f49-88d4ca87a555", dict(video=1)),
-    ("https://mvau.lt/media/ccfa5e89-a89d-4a12-aee1-cf68dcb205ce", dict(image=1)),
-    ("https://web.archive.org/web/20210604181412/https://www.tiktok.com/@realstewpeters/video/6969789589590379781?is_copy_url=1", dict(video=1)),
-    ("http://web.archive.org/web/20230308184253/https://newspunch.com/hungary-prepares-to-prosecute-lifelong-nazi-george-soros-for-holocaust-atrocities/", dict(video=3, image=1)),
-    ("https://ghostarchive.org/archive/d63Zd", dict(image=1)),
-    ("https://ghostarchive.org/archive/gz80n", dict(video=1)),
-    ("https://www.awesomescreenshot.com/image/40260716?key=c50159e80af3be1d003aa5235d3edaa9", dict(image=1)),
-    ("https://www.awesomescreenshot.com/video/11862930?key=b021c372bb96716fdbb2316d0eb37c69", dict(video=1))
+    # Other archiving services (not supported yet):
+    # ("https://mvau.lt/media/b286c959-00da-4765-8f49-88d4ca87a555", dict(video=1)),
+    # ("https://mvau.lt/media/ccfa5e89-a89d-4a12-aee1-cf68dcb205ce", dict(image=1)),
+    # ("https://web.archive.org/web/20210604181412/https://www.tiktok.com/@realstewpeters/video/6969789589590379781?is_copy_url=1", dict(video=1)),
+    # ("http://web.archive.org/web/20230308184253/https://newspunch.com/hungary-prepares-to-prosecute-lifelong-nazi-george-soros-for-holocaust-atrocities/", dict(video=3, image=1)),
+    # ("https://ghostarchive.org/archive/d63Zd", dict(image=1)),
+    # ("https://ghostarchive.org/archive/gz80n", dict(video=1)),
+    # ("https://www.awesomescreenshot.com/image/40260716?key=c50159e80af3be1d003aa5235d3edaa9", dict(image=1)),
+    # ("https://www.awesomescreenshot.com/video/11862930?key=b021c372bb96716fdbb2316d0eb37c69", dict(video=1))
 ])
 async def test_archiving_service(url: str, expected: dict[str, int]):
     result = await retrieve(url)

--- a/testing/test_download.py
+++ b/testing/test_download.py
@@ -27,7 +27,8 @@ from scrapemm.download.videos import is_maybe_video_url
     ("https://platform.vox.com/wp-content/uploads/sites/2/2025/04/jack-black-wink-minecraft.avif?quality=90&strip=all&crop=12.5%2C0%2C75%2C100&w=2400",
      True),
     ("https://media.cnn.com/api/v1/images/stellar/prod/02-overview-of-kursk-training-area-15april2025-wv2.jpg?q=w_1110,c_fill",
-     True)
+     True),
+    ("https://mediaproxy.snopes.com/width/1200/https://media.snopes.com/2024/01/origin_of_gauze.jpg", True)
 ])
 @pytest.mark.asyncio
 async def test_is_image_url(url, expected):
@@ -47,6 +48,7 @@ async def download_img(url):
     "https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/MBWA4LJ5XLVC6CJLZG2OQFMGWE.JPG&w=1440&impolicy=high_res",
     "https://factuel.afp.com/sites/default/files/styles/header_article/public/medias/factchecking/g2/2025-07/c1452a5562cfe3e178b0d5c6681c940e-fr.jpeg?itok=a9Wc3hEY",
     "https://archive.is/uTVE4/da2c6541801809f1b665e8992f7d214621ec9443/scr.png",
+    "https://mediaproxy.snopes.com/width/1200/https://media.snopes.com/2024/01/origin_of_gauze.jpg",
 ])
 async def test_download_image(url):
     img = await download_img(url)

--- a/testing/test_retrieval.py
+++ b/testing/test_retrieval.py
@@ -11,7 +11,7 @@ from scrapemm import retrieve
     "https://health.medicaldialogues.in/fact-check/brain-health-fact-check/fact-check-is-sprite-the-best-remedy-for-headaches-in-the-world-140368",
     "https://www.washingtonpost.com/politics/2024/05/15/bidens-false-claim-that-inflation-was-9-percent-when-he-took-office/",
     "https://assamese.factcrescendo.com/viral-claim-that-the-video-shows-the-incident-from-uttar-pradesh-and-the-youth-on-the-bike-and-the-youth-being-beaten-and-taken-away-by-the-police-are-the-same-youth-named-abdul-is-false/",
-    "https://factuel.afp.com/doc.afp.com.43ZN7NP",
+    # "https://factuel.afp.com/doc.afp.com.43ZN7NP",
     "https://leadstories.com/365cb414b83e29d26fecae374d55c743a3eac4c7.png",
     "https://leadstories.com/assets_c/2025/08/193f14f06dd6f15b89bf8050e553ad7fb1be6530-thumb-900xauto-3165872.png"
 ])

--- a/testing/test_social_media.py
+++ b/testing/test_social_media.py
@@ -66,14 +66,10 @@ async def test_instagram(url: str, expected: dict[str, int]):
     ("https://www.facebook.com/reel/1954696035077530", dict(video=1)),
     ("https://www.facebook.com/reel/1089214926521000", dict(video=1)),
     ("https://www.facebook.com/reel/3466446073497470", dict(video=1)),  # restricted for misinformation
-    ("https://m.facebook.com/watch/?v=567654417277309", dict(video=1)),
-    ("https://www.facebook.com/S.Angel000/videos/2081147972022130/", dict(video=1)),
     ("https://fb.watch/dmMvfqIFqC/", dict(video=1)),
-    ("https://www.facebook.com/61561558177010/videos/1445957793080961/", dict(video=1)),
-    ("https://www.facebook.com/watch/?v=1445957793080961", dict(video=1)),
-    ("https://www.facebook.com/watch/?v=502482344935053", dict(video=1)),  # requires login
-    # restricted for misinformation, yt-dlp fails here:
-    ("https://www.facebook.com/groups/1973976962823632/posts/3992825270938781/", dict(video=1)),
+    ("https://www.facebook.com/watch/?v=502482344935053", dict(video=1)),
+    # restricted for misinformation, accessible only with cookie:
+    ("https://www.facebook.com/groups/1973976962823632/posts/3992825270938781/", dict(image=1)),
 ])
 async def test_facebook(url: str, expected: dict[str, int]):
     """Test Facebook reel and photo retrieval"""


### PR DESCRIPTION
Introduces support for photos in facebook posts.

Comprises:
- Regular photos in posts
- Photos behind login redirects
- Photos behind post permalinks